### PR TITLE
Update to mavlink 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ async-trait = "0.1"
 blocking = "1.0"
 futures = "0.3"
 lazy_static = "1.4"
-mavlink = "0.10"
+mavlink = "0.12"
 thiserror = "1.0"
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]
-simple_logger = "1"
+simple_logger = "4.2"
 smol = "1"
 log = "*"
 

--- a/examples/fetch_parameters.rs
+++ b/examples/fetch_parameters.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), AsyncMavlinkError> {
         let mut parameters = HashMap::new();
         info!("beginning to collect the parameters into a HashMap");
         while let Some(MavMessage::PARAM_VALUE(data)) = (stream.next()).await {
-            let name = to_string(&data.param_id);
+            let name = decode_param_id(&data.param_id);
             trace!(
                 "storing parameter {:>4}/{:<4} {:>16}\r",
                 parameters.len(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ mod types;
 mod util;
 
 pub use types::{AsyncMavlinkError, MavMessageType};
-pub use util::{to_char_arr, to_string};
+pub use util::encode_param_id;
 
 /// An async adapter for a MAVLink connection
 ///

--- a/src/microservices/parameter_protocol.rs
+++ b/src/microservices/parameter_protocol.rs
@@ -185,7 +185,7 @@ impl<F: FnMut() -> Box<dyn Future<Output = T> + Unpin>, T, const N: usize, const
                 let msg = MavMessage::PARAM_SET(mavlink::common::PARAM_SET_DATA {
                     target_system: self.target_system_id,
                     target_component: self.target_component_id,
-                    param_id: to_char_arr(param_name),
+                    param_id: encode_param_id(param_name),
                     param_value,
                     param_type: *param_type,
                 });
@@ -263,7 +263,7 @@ impl<F: FnMut() -> Box<dyn Future<Output = T> + Unpin>, T, const N: usize, const
             // We now have the param with this value in cache
             self.missing_indeces.remove(param_index);
             self.params
-                .insert(to_string(param_id), (*param_value, *param_type));
+                .insert(decode_param_id(param_id), (*param_value, *param_type));
         } else {
             panic!("this is impossible");
         }
@@ -335,7 +335,7 @@ impl<F: FnMut() -> Box<dyn Future<Output = T> + Unpin>, T, const N: usize, const
         MavMessage::PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA {
             target_system: self.target_system_id,
             target_component: self.target_component_id,
-            param_id: to_char_arr(param_id),
+            param_id: encode_param_id(param_id),
             param_index,
         })
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,18 +1,14 @@
-/// Extract String from mavlink's PARAM_VALUE_DATA struct
-pub fn to_string(input_slice: &[char]) -> String {
-    input_slice
-        .iter()
-        .filter(|c| **c != char::from(0))
-        .collect()
+/// Decode param_id from mavlink's PARAM_VALUE_DATA struct
+pub fn decode_param_id(bytes: &[u8; 16]) -> String {
+    std::str::from_utf8(bytes)
+        .unwrap()
+        .trim_end_matches('\0')
+        .to_string()
 }
 
-/// Create char array for mavlink's PARAM_VALUE_DATA struct
-pub fn to_char_arr(input: &str) -> [char; 16] {
-    let mut result = [' '; 16];
-    input
-        .chars()
-        .enumerate()
-        .take(16)
-        .for_each(|(i, e)| result[i] = e);
-    result
+/// Encode param_id from mavlink's PARAM_VALUE_DATA struct
+pub fn encode_param_id(name: &str) -> [u8; 16] {
+    let mut bytes = [0u8; 16];
+    bytes[..name.len()].copy_from_slice(name.as_bytes());
+    bytes
 }


### PR DESCRIPTION
Hi, I just found out about this crate after reading your comments in the `mavlink` repo about how the API could be improved and should be made async. I'm making a desktop app to configure the ArduPilot OSD layout and I ran into some of the pain points you described. I'd like to use this library instead of the synchronous one but noticed it not compatible with `mavlink` 0.12 so here's a PR to update the dependency. 

In the README you mention this library is just a POC but not if there's anything missing. Since it's just a thin wrapper around the synchronous API it seem quite complete if you only want to read and set parameters. Is that correct?